### PR TITLE
Merge queue stuff and add a testing suite

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -10,7 +10,8 @@
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                 "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                "${workspaceFolder}"
+                "${workspaceRoot}/project2/libs/tests",
+                "${workspaceRoot}"
             ],
             "defines": [
                 "__AVR_ATmega2560__"
@@ -25,7 +26,8 @@
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                     "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                    "${workspaceFolder}"
+                    "${workspaceRoot}/project2/libs/tests",
+                    "${workspaceRoot}"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
@@ -45,7 +47,8 @@
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                 "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                "${workspaceFolder}"
+                "${workspaceRoot}/project2/libs/tests",
+                "${workspaceRoot}"
             ],
             "defines": [
                 "__AVR_ATmega2560__"
@@ -60,7 +63,8 @@
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                     "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                    "${workspaceFolder}"
+                    "${workspaceRoot}/project2/libs/tests",
+                    "${workspaceRoot}"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
@@ -74,7 +78,8 @@
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                 "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                 "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                "${workspaceFolder}"
+                "${workspaceRoot}/project2/libs/tests",
+                "${workspaceRoot}"
             ],
             "defines": [
                 "_DEBUG",
@@ -90,7 +95,8 @@
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/cores/arduino",
                     "${env:ARDUINO_DIR}/hardware/arduino/avr/variants/mega",
                     "${env:ARDUINO_DIR}/hardware/tools/avr/lib/gcc/avr/4.9.2/include",
-                    "${workspaceFolder}"
+                    "${workspaceRoot}/project2/libs/tests",
+                    "${workspaceRoot}"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""

--- a/project2/Makefile
+++ b/project2/Makefile
@@ -1,4 +1,4 @@
-# USER_LIB_PATH=$(realpath ../common)
+USER_LIB_PATH=$(realpath libs)
 
 BOARD_TAG    = mega
 BOARD_SUB    = atmega2560

--- a/project2/Makefile
+++ b/project2/Makefile
@@ -1,9 +1,6 @@
 USER_LIB_PATH=$(realpath libs)
-
 BOARD_TAG    = mega
 BOARD_SUB    = atmega2560
 ARDUINO_PORT = ${BASE_PORT}
-include ${ARDMK_DIR}/Arduino.mk
 
-switch:
-	avr-gcc -c -O2 -DF_CPU=${CLOCK} -mmcu=${BOARD_SUB} -Wa,--gstabs -o cswitch.S.o cswitch.S
+include ${ARDMK_DIR}/Arduino.mk

--- a/project2/common.h
+++ b/project2/common.h
@@ -63,22 +63,22 @@ typedef void (*voidfuncptr) (void);      /* pointer to void f(void) */
 /**
  * This is the set of possible task priority levels
  */
-typedef enum priority_levels {
+typedef enum priority_level {
     SYSTEM = 0,
     PERIODIC,
     RR,
     NUM_PRIORITY_LEVELS /* Must be last */
-} PRIORITY_LEVELS;
+} PRIORITY_LEVEL;
 
 /**
  *  This is the set of states that a task can be in at any given time.
  */
-typedef enum process_states {
+typedef enum process_state {
     DEAD = 0,
     READY,
     RUNNING,
     NUM_PROCESS_STATES /* Must be last */
-} PROCESS_STATES;
+} PROCESS_STATE;
 
 /**
  * This is the set of kernel requests, i.e., a request code for each system call.

--- a/project2/kernel.c
+++ b/project2/kernel.c
@@ -9,9 +9,11 @@ volatile static PD* Cp;
 
 /**
  * This table contains ALL process descriptors. It doesn't matter what
- * state a task is in.
+ * state a task is in. This table also serves as storage for the elements of
+ * the task_queues. A task queue keeps track of the priority it manages, and won't enqueue
+ * tasks that have the wrong priority. Doing it this way saves memory by allowing all three
+ * queues to use the same storage, with the assurance that they won't overwrite eachother.
  */
-// TODO: Replace with Priority based queues
 static PD Process[MAXTHREAD];
 
 task_queue_t system_tasks;

--- a/project2/libs/tests/queue_test.c
+++ b/project2/libs/tests/queue_test.c
@@ -1,0 +1,167 @@
+#include "../../common.h"
+#include "../../process.h"
+#include <avr/io.h>
+#include <util/delay.h>
+
+#define Assert(expr) \
+{\
+if (!(expr)) while (TRUE);\
+}
+
+void Task_Queue_Test() {
+
+    DDRB = 0xFF;
+    PORTB = 0;
+
+    BIT_SET(PORTB, 0);
+
+    task_queue_t rr_test_queue;
+    task_queue_t sy_test_queue;
+    task_queue_t pr_test_queue;
+    task_queue_t test_queue;
+
+    PD rr_test_task1;
+    PD rr_test_task2;
+    PD rr_test_task3;
+    PD sy_test_task;
+    PD pr_test_task;
+
+    ZeroMemory(rr_test_task1, sizeof(PD));
+    ZeroMemory(rr_test_task2, sizeof(PD));
+    ZeroMemory(rr_test_task3, sizeof(PD));
+    ZeroMemory(sy_test_task, sizeof(PD));
+    ZeroMemory(pr_test_task, sizeof(PD));
+
+    rr_test_task1.priority = RR;
+    rr_test_task2.priority = RR;
+    rr_test_task3.priority = RR;
+
+    sy_test_task.priority = SYSTEM;
+    pr_test_task.priority = PERIODIC;
+
+    /////////////////////////////////////////////////////
+    // Initialization succeeds
+    /////////////////////////////////////////////////////
+    Assert(queue_init(&test_queue, NUM_PRIORITY_LEVELS) == NULL); // Doesn't initialize with bad priority
+
+    Assert(queue_init(&sy_test_queue, SYSTEM) != NULL); // Initialized result is returned
+    Assert(sy_test_queue.length == 0); // Queue is empty upon initialization
+    Assert(sy_test_queue.head == NULL); // Queue head is null upon initialization
+    Assert(sy_test_queue.tail == NULL); // Queue tail is null initialization
+    Assert(sy_test_queue.type == SYSTEM); // Queue type is set correctly
+
+    Assert(queue_init(&pr_test_queue, PERIODIC) != NULL); // Initialized result is returned
+    Assert(pr_test_queue.head == NULL); // Queue head is null upon initialization
+    Assert(pr_test_queue.tail == NULL); // Queue tail is null initialization
+    Assert(pr_test_queue.length == 0); // Queue is empty upon initialization
+    Assert(pr_test_queue.type == PERIODIC); // Queue type is set correctly
+
+    Assert(queue_init(&rr_test_queue, RR) != NULL); // Initialized result is returned
+    Assert(rr_test_queue.head == NULL); // Queue head is null upon initialization
+    Assert(rr_test_queue.tail == NULL); // Queue tail is null initialization
+    Assert(rr_test_queue.length == 0); // Queue is empty upon initialization
+    Assert(rr_test_queue.type == RR); // Queue type is set correctly
+
+    // One flip to show success
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_ms(1);
+
+    /////////////////////////////////////////////////////
+    // Adding tasks succeeds
+    /////////////////////////////////////////////////////
+    enqueue(&sy_test_queue, &sy_test_task);
+    Assert(sy_test_queue.head == &sy_test_task); // Task added is the one we added
+    Assert(sy_test_queue.head == sy_test_queue.tail); // One task is accessed by head and tail
+    Assert(sy_test_queue.length == 1); // Have added one task, length reflects that
+
+    enqueue(&sy_test_queue, &pr_test_task); // Adding the wrong type of task is ignored
+    Assert(sy_test_queue.head == sy_test_queue.tail); // Queue remains unchanged
+    Assert(sy_test_queue.length == 1); // Queue remains unchanged
+
+    // Two flips to show success
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_us(3);
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_ms(1);
+
+    /////////////////////////////////////////////////////
+    // Adding multiple tasks succeeds
+    /////////////////////////////////////////////////////
+    enqueue(&rr_test_queue, &rr_test_task1);
+    Assert(rr_test_queue.head == rr_test_queue.tail); // One element, head and tail are same
+    Assert(rr_test_queue.length == 1); // One element, length is one
+
+    enqueue(&rr_test_queue, &rr_test_task2);
+    Assert(rr_test_queue.head != rr_test_queue.tail); // Two elements, head and tail differ
+    Assert(rr_test_queue.head->next == rr_test_queue.tail); // Two elements, head's next is tail
+    Assert(rr_test_queue.length == 2); // Two elements, length is two
+
+    enqueue(&rr_test_queue, &rr_test_task3);
+    Assert(rr_test_queue.head != rr_test_queue.tail); // Three elements, head and tail differ
+    Assert(rr_test_queue.head->next->next == rr_test_queue.tail); // Three elements, head.next's next is tail
+    Assert(rr_test_queue.length == 3); // Three elements, length is three
+
+    Assert(rr_test_queue.head == &rr_test_task1); // Tasks are in order
+    Assert(rr_test_queue.head->next == &rr_test_task2);
+    Assert(rr_test_queue.tail == &rr_test_task3);
+
+    // Three flips this time to show success
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_us(3);
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_us(3);
+    BIT_FLIP(PORTB, 1);
+    BIT_FLIP(PORTB, 1);
+    _delay_ms(1);
+
+    /////////////////////////////////////////////////////
+    // Removing and peeking at tasks succeeds
+    /////////////////////////////////////////////////////
+    PD* first = peek(&rr_test_queue);
+    Assert(first != NULL); // Got something
+    Assert(first == &rr_test_task1); // Expected item is returned
+    Assert(rr_test_queue.length == 3) // Length is unchanged
+    Assert(rr_test_queue.head == first); // Item is still in queue
+
+    PD* deq1 = deque(&rr_test_queue);
+    Assert(deq1 != NULL); // Got something
+    Assert(deq1->next == NULL); // Item doesn't refer to queue anymore
+    Assert(first == deq1); // Expected item was returned
+    Assert(first == &rr_test_task1); // Expected item is returned
+    Assert(rr_test_queue.length == 2); // Length was updated
+    Assert(rr_test_queue.head != deq1); // Dequeued item is no longer in the queue
+    Assert(rr_test_queue.head->next != deq1); // Dequeued item is no longer in the queue
+
+    PD* deq2 = deque(&rr_test_queue);
+    Assert(deq2 != NULL); // Got something from subsequent dequeue
+    Assert(deq2->next == NULL); // Item doesn't refer to queue anymore
+    Assert(deq1 != deq2); // It's different from what we saw previously
+    Assert(deq2 == &rr_test_task2); // Expected item was returned
+    Assert(rr_test_queue.length == 1); // Length was updated
+    Assert(rr_test_queue.head == rr_test_queue.tail); // One item left, head and tail should point to it
+
+    PD* last = peek(&rr_test_queue);
+    PD* deq3 = deque(&rr_test_queue);
+    Assert(deq3 != NULL); // Got something from subsequent dequeue
+    Assert(deq3->next == NULL); // Item doesn't refer to queue anymore
+
+    Assert(first != last); // Peek is different from last peek
+    Assert(last == deq3); // Peek is same as subsequent dequeue
+    Assert(deq1 != deq3); // It's different from what we saw previously
+    Assert(deq2 != deq3); // It's different from what we saw previously
+    Assert(deq3 == &rr_test_task3); // Expected item was returned
+    Assert(rr_test_queue.length == 0); // Length was updated
+    Assert(rr_test_queue.head == NULL); // Nothing left, head is null
+    Assert(rr_test_queue.tail == NULL); // Nothing left, tail is null
+
+    Assert(peek(&rr_test_queue) == NULL); // Didn't get anything from peeking empty queue
+    Assert(deque(&rr_test_queue) == NULL); // Didn't get anything from dequeueing empty queue
+
+    BIT_SET(PORTB, 1);
+    BIT_CLR(PORTB, 0);
+}

--- a/project2/libs/tests/queue_test.c
+++ b/project2/libs/tests/queue_test.c
@@ -10,11 +10,7 @@ if (!(expr)) while (TRUE);\
 
 void Task_Queue_Test() {
 
-    DDRB = 0xFF;
-    PORTB = 0;
-
     BIT_SET(PORTB, 0);
-
     task_queue_t rr_test_queue;
     task_queue_t sy_test_queue;
     task_queue_t pr_test_queue;

--- a/project2/libs/tests/test_list.h
+++ b/project2/libs/tests/test_list.h
@@ -1,0 +1,7 @@
+#ifndef _TEST_LIST_H_
+#define  _TEST_LIST_H_
+
+// List all tests here
+void Task_Queue_Test();
+
+#endif

--- a/project2/libs/tests/test_suite.c
+++ b/project2/libs/tests/test_suite.c
@@ -1,0 +1,39 @@
+
+#include <avr/io.h>
+#include "tests.h"
+#include "test_list.h"
+
+void Test_Suite(TEST_MASKS mask) {
+    // Set everything to output low
+    DDRA  = 0xFF;
+    PORTA = 0;
+    DDRB  = 0xFF;
+    PORTB = 0;
+    DDRC  = 0xFF;
+    PORTC = 0;
+    DDRD  = 0xFF;
+    PORTD = 0;
+
+
+    // Raise PD0 while any tests are active
+    BIT_SET(PORTD, 0);
+    // is TEST_QUEUE in the mask?
+    if ((mask & TEST_QUEUE) == TEST_QUEUE) {
+        BIT_SET(PORTD, 1);
+        Task_Queue_Test();
+        BIT_CLR(PORTD, 1);
+    }
+
+    /* Example for another masked test
+    // is TEST_THING in the mask?
+    if ((mask & TEST_THING) == TEST_THING) {
+        BIT_SET(PORTD, 1);
+        Test_Thing();
+        BIT_CLR(PORTD, 1);
+    }
+    */
+
+    // All tests passed, since if an asset fails the board hangs there
+    // Set PD0 back to low
+    BIT_CLR(PORTD, 0);
+}

--- a/project2/libs/tests/tests.h
+++ b/project2/libs/tests/tests.h
@@ -1,0 +1,6 @@
+#ifndef _TESTS_H_
+#define _TESTS_H_
+
+void Task_Queue_Test(void);
+
+#endif

--- a/project2/libs/tests/tests.h
+++ b/project2/libs/tests/tests.h
@@ -1,6 +1,28 @@
 #ifndef _TESTS_H_
 #define _TESTS_H_
 
-void Task_Queue_Test(void);
+/**
+ * To run tests, include this file from main.c and call Test_Suite(...)
+ * with the masks for the tests you would like to run,
+ *    eg  Test_Suite(TEST_THING)                        // To test one thing
+ *    or  Test_Suite(TEST_THING | TEST_OTHER_THING)     // To test multiple things
+ *    or  Test_Suite(TEST_ALL)                          // To run all tests
+ */
+
+typedef enum {
+    TEST_QUEUE          = 0x01,
+    // TEST_THING       = 0x02,
+    // TEST_OTHER_THING = 0x04,
+    // TEST_NEXT_THING  = 0x08,
+    TEST_ALL            = 0xFF // ie: TEST_QUEUE | TEST_THING | TEST_OTHER_THING | TEST_NEXT_THING ...
+} TEST_MASKS;
+
+/**
+ * Runs all tests specified by the provided mask
+ * Sets all pins to output low before testing
+ * Raises PD0 while any tests are active
+ * Raises PD1 while each specifed test is active
+ */
+void Test_Suite(TEST_MASKS);
 
 #endif

--- a/project2/main.c
+++ b/project2/main.c
@@ -4,8 +4,6 @@
 #include "kernel.h"
 #include "common.h"
 
-#include "tests.h"
-
 /**
  * A cooperative "Ping" task.
  * Added testing code for LEDs.
@@ -26,6 +24,7 @@ void Pong() TASK
     _delay_ms(1000);
 })
 
+
 /**
  * This function creates two cooperative tasks, "Ping" and "Pong". Both
  * will run forever.
@@ -35,12 +34,10 @@ int main() {
 
     // TODO: Shouldn't have to manually init and start os.
     // Kernel should start user code instead
-    // Kernel_Init();
-    // Task_Create(Pong);
-    // Task_Create(Ping);
-    // Kernel_Start();
-
-    Task_Queue_Test();
+    Kernel_Init();
+    Task_Create(Pong);
+    Task_Create(Ping);
+    Kernel_Start();
 
     /* Never reaches this point */
     return -1;

--- a/project2/main.c
+++ b/project2/main.c
@@ -4,6 +4,8 @@
 #include "kernel.h"
 #include "common.h"
 
+#include "tests.h"
+
 /**
  * A cooperative "Ping" task.
  * Added testing code for LEDs.
@@ -33,10 +35,12 @@ int main() {
 
     // TODO: Shouldn't have to manually init and start os.
     // Kernel should start user code instead
-    Kernel_Init();
-    Task_Create(Pong);
-    Task_Create(Ping);
-    Kernel_Start();
+    // Kernel_Init();
+    // Task_Create(Pong);
+    // Task_Create(Ping);
+    // Kernel_Start();
+
+    Task_Queue_Test();
 
     /* Never reaches this point */
     return -1;

--- a/project2/process.c
+++ b/project2/process.c
@@ -1,16 +1,80 @@
 #include "process.h"
 
-void queue_init(task_queue_t* list) {
+/**
+ * Initializes a task queue for tracking a certain priority task.
+ * Returns a pointer to the initialized list if successfull.
+ */
+task_queue_t* queue_init(task_queue_t* list, PRIORITY_LEVEL type) {
+    // Have a non-null pointer, and a valid priority type
+    // All conditions inside inner-most parens must be true to continue
+    if (!(list && type < NUM_PRIORITY_LEVELS)) {
+        return NULL;
+    }
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->length = 0;
+    list->type = type;
+
+    return list;
 }
 
+/**
+ * Enqueues a task at the end of the queue iff the task type matches the queue type.
+ */
 void enqueue(task_queue_t* list, PD* task) {
+    // Have non-null list and task, and the queue type matches the task priority.
+    // All conditions inside inner-most parens must be true to continue
+    if (!(list && task && list->type != task->priority)) {
+        return;
+    }
 
+    if (list->length == 0) {
+        list->head = task;
+        list->tail = task;
+        list->length = 1;
+    } else {
+        list->tail->next = task;
+        list->tail = task;
+        list->length += 1;
+    }
 }
 
+/**
+ * Dequeues the first task from the queue
+ * Returns the dequeued task or NULL if the queue is empty
+ */
 PD* deque(task_queue_t* list) {
-    return NULL;
+    // Have a non-null list, and its length is greater than 0
+    // All conditions inside inner-most parens must be true to continue
+    if (!(list && list->length > 0)) {
+        return NULL;
+    }
+
+    PD* element = list->head;
+    list->length -= 1;
+    if (list->length == 0) {
+        // Nothing left in the queue, reset it
+        list = queue_init(list, list->type);
+    } else {
+        // Still have some items left, clean up
+        list->head = element->next;
+        element->next = NULL;
+    }
+
+    return element;
 }
 
+/**
+ * Peeks at the first task in the queue
+ * Returns the task without dequeueing it
+ */
 PD* peek(task_queue_t* list) {
-    return NULL;
+    // Have a non-null list
+    // All conditions inside inner-most parens must be true to continue
+    if (!(list)) {
+        return NULL;
+    }
+
+    return list->head;
 }

--- a/project2/process.c
+++ b/project2/process.c
@@ -25,7 +25,7 @@ task_queue_t* queue_init(task_queue_t* list, PRIORITY_LEVEL type) {
 void enqueue(task_queue_t* list, PD* task) {
     // Have non-null list and task, and the queue type matches the task priority.
     // All conditions inside inner-most parens must be true to continue
-    if (!(list && task && list->type != task->priority)) {
+    if (!(list && task && list->type == task->priority)) {
         return;
     }
 

--- a/project2/process.h
+++ b/project2/process.h
@@ -10,20 +10,23 @@
  * the task's stack, i.e., its workspace, in here.
  */
 typedef struct ProcessDescriptor {
-    volatile uint8_t*       sp;                   /* stack pointer into the "workSpace" */
-    uint8_t                 workSpace[WORKSPACE];
-    volatile PROCESS_STATES state;
-    voidfuncptr             code;                 /* function to be executed as a task */
-    KERNEL_REQUEST_TYPE     request;
+    volatile uint8_t*         sp;                   /* stack pointer into the "workSpace" */
+    uint8_t                   workSpace[WORKSPACE];
+    volatile PROCESS_STATE    state;
+    voidfuncptr               code;                 /* function to be executed as a task */
+    KERNEL_REQUEST_TYPE       request;
+    const PRIORITY_LEVEL      priority;
+    struct ProcessDescriptor* next;
 } PD;
 
 typedef struct task_queue_type {
     PD* head;
     PD* tail;
     uint8_t length;
+    PRIORITY_LEVEL type;
 } task_queue_t;
 
-void queue_init(task_queue_t* list);
+task_queue_t* queue_init(task_queue_t* list, PRIORITY_LEVEL type);
 
 PD*  peek   (task_queue_t* list);
 PD*  deque  (task_queue_t* list);

--- a/project2/process.h
+++ b/project2/process.h
@@ -15,7 +15,7 @@ typedef struct ProcessDescriptor {
     volatile PROCESS_STATE    state;
     voidfuncptr               code;                 /* function to be executed as a task */
     KERNEL_REQUEST_TYPE       request;
-    const PRIORITY_LEVEL      priority;
+    PRIORITY_LEVEL            priority;
     struct ProcessDescriptor* next;
 } PD;
 


### PR DESCRIPTION
Implemented task queues, they just link `PD`'s from the kernel's `static PD Process[MAXTHREAD]` array. For the `PD`'s to actually point at the next element in the queue I added a `.next` pointer. Each queue tracks its priority level and won't enqueue tasks with the wrong priority (that don't belong in that queue). 

Also ran a big test against the queues, and moved that testing code into a hacked together 'test suite' as a library. Proof the tests passed is shown by channel 0 returning to low voltage:

![capture](https://user-images.githubusercontent.com/11222441/37247905-888f870c-2478-11e8-841e-f8aa5222d58f.PNG)
